### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/hazzureddy84/cc0b0d38-0361-4165-b7a0-a0c1af1e8763/94da8f94-8fd4-4fcd-9516-61d989be154b/_apis/work/boardbadge/1de21a4f-c4af-4fd1-8187-a169f26761ca)](https://dev.azure.com/hazzureddy84/cc0b0d38-0361-4165-b7a0-a0c1af1e8763/_boards/board/t/94da8f94-8fd4-4fcd-9516-61d989be154b/Microsoft.RequirementCategory)
 # demoprojects


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hazzureddy84/cc0b0d38-0361-4165-b7a0-a0c1af1e8763/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.